### PR TITLE
Rework the workflow select

### DIFF
--- a/_layouts/document.html
+++ b/_layouts/document.html
@@ -25,11 +25,11 @@ workspace_module: docs
                 </a>
                 <a class="icon-info-circle meta-data-toggle iconified" title="Show extra metadata fields">Toggle extra metadata</a>
                 <fieldset class="pat-subform pat-autosubmit pat-inject" data-pat-inject="target: #document-content::before; url: /feedback/banner-notifications.html; source: #workflow-state-changed::element;">
-                    <label class="pat-select bare" title="Change the workflow state">
+                    <label class="pat-select bare workflow" title="Change the workflow state">
+                        Private
                         <select>
-                            <option>Private</option>
-                            <option>Pending</option>
-                            <option>Published</option>
+                            <option>Submit</option>
+                            <option>Publish</option>
                             <!-- <option>Members</option> -->
                             <!-- <option>Logged in</option> -->
                             <!-- <option>Internal</option> -->

--- a/_sass/libraries/patterns/components/_select.scss
+++ b/_sass/libraries/patterns/components/_select.scss
@@ -25,6 +25,11 @@ label.pat-select.bare:after {
   box-shadow: none !important;
 }
 
+label.pat-select.bare.workflow:after {
+  content: ' ▼';
+  box-shadow: none !important;
+}
+
 label.pat-select.bare select {
   opacity: 0;
   line-height: 1.5em;


### PR DESCRIPTION
The current way in which pat-select and the workflow dropdown functioned is not
representative to how workflow changing happens in Plone.

In Plone, you don't have a list of state names to choose from, you have a list
of so-called "transitions" to choose from, and when you choose a transition,
you move from one state to another.

I've therefore modified the proto a bit to show the fact that the wofkflow
dropdown shows a state in its label, but when you open the select you get a
list of transitions.

CC @cornae 