### PR TITLE
Control overly long titles

### DIFF
--- a/_posts/workspaces/supplying-publications/2014-03-04-supplying-publications.md
+++ b/_posts/workspaces/supplying-publications/2014-03-04-supplying-publications.md
@@ -1,9 +1,8 @@
 ---
 layout: workspace-landing
-title: Supplying publications to MEPs
-workspace_name: Supplying publications to MEPs
-description: "UK Members of the European Parliament (MEPs) are eligible to
-receive up to two copies of any qualifying UK Official publication."
+title: "This is an example for an overly long title containing log words like Antidisestablishmentarianism which is typically used by organisations in the german speaking parts of europe, partly because of cultural reasons, partly because the concept of descriptions is not yet fully adopted."
+workspace_name: "This is an example for an overly long title containing log words like Antidisestablishmentarianism which is typically used by organisations in the german speaking parts of europe, partly because of cultural reasons, partly because the concept of descriptions is not yet fully adopted."
+description: "And therefore we need to employ means of cropping and hyphenation."
 application: workspace
 mutations:
   - verb: changed start date of

--- a/_sass/components/_breadcrumbs.scss
+++ b/_sass/components/_breadcrumbs.scss
@@ -38,6 +38,12 @@ nav.breadcrumbs {
     &.has-siblings:after {
       right: -43px;
     }
+    &.current {
+      width: 30em;
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+    }
     &.current:after {
       display: none;
     }

--- a/_sass/components/_tiles.scss
+++ b/_sass/components/_tiles.scss
@@ -125,6 +125,12 @@
 	      font-weight: 100;
 	      font-size: 2em;
 	      line-height: 1.2em;
+		   overflow-wrap: break-word;
+		   word-wrap: break-word;
+		   -webkit-hyphens: auto;
+		   -ms-hyphens: auto;
+		   -moz-hyphens: auto;
+		   hyphens: auto;
 	    }
 
 	    p {


### PR DESCRIPTION
A problem demo and proposal for solution
<img width="329" alt="bildschirmfoto 2015-08-26 um 12 23 43" src="https://cloud.githubusercontent.com/assets/138906/9546113/4f72f6f0-4d90-11e5-8eae-de2b19a73ba1.png">
@cornae Remember I showed you that crazily long title for a workspace? This adds an example and a fix proposal, to trigger you to fix it correctly instead. 

I tested this in FF, Chrome, Safari and IE10 and it works. In Safari we even get dashes when hyphenating.